### PR TITLE
Updated URL to point to Git Hub

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email='luc.jean@gmail.com',
     maintainer='Luc Jean',
     maintainer_email='luc.jean@gmail.com',
-    url='http://code.google.com/p/modbus-tk/',
+    url='https://github.com/ljean/modbus-tk/',
     license='LGPL',
     packages=['modbus_tk'],
     platforms=["Linux", "Mac OS X", "Win"],


### PR DESCRIPTION
URL field is used by PyPi to display location of home page - this has moved from code.google.com to guthub.

Addresses #47