### PR TITLE
Remove dependency on six module

### DIFF
--- a/modbus_tk/simulator.py
+++ b/modbus_tk/simulator.py
@@ -18,10 +18,9 @@ import os
 import sys
 import select
 import serial
-import six
 import threading
 import time
-if six.PY2:
+if utils.PY2:
     import Queue
     import SocketServer
 else:

--- a/modbus_tk/utils.py
+++ b/modbus_tk/utils.py
@@ -14,9 +14,10 @@ import threading
 import logging
 import socket
 import select
-import six
 from modbus_tk import LOGGER
 
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
 
 def threadsafe_function(fcn):
     """decorator making sure that the decorated function is thread safe"""
@@ -56,7 +57,7 @@ def get_log_buffer(prefix, buff):
     """Format binary data into a string for debug purpose"""
     log = prefix
     for i in buff:
-        log += str(ord(i) if six.PY2 else i) + "-"
+        log += str(ord(i) if PY2 else i) + "-"
     return log[:-1]
 
 
@@ -84,7 +85,7 @@ class LogitHandler(logging.Handler):
     def emit(self, record):
         """format and send the record over udp"""
         data = self.format(record) + "\r\n"
-        if six.PY3:
+        if PY3:
             data = to_data(data)
         self._sock.sendto(data, self._dest)
 
@@ -133,7 +134,7 @@ def calculate_crc(data):
     """Calculate the CRC16 of a datagram"""
     crc = 0xFFFF
     for i in data:
-        if six.PY2:
+        if PY2:
             crc = crc ^ ord(i)
         else:
             crc = crc ^ i
@@ -192,7 +193,7 @@ class WorkerThread(object):
 
 
 def to_data(string_data):
-    if six.PY2:
+    if PY2:
         return string_data
     else:
         return bytearray(string_data, 'ascii')


### PR DESCRIPTION
Small change to remove dependency on the six module since modbus_tk seems to only use 2 lines from the module. Instead we can just add this to utils.