### PR TITLE
Removes time.sleep() in RtuMaster._send()

### DIFF
--- a/modbus_tk/modbus_rtu.py
+++ b/modbus_tk/modbus_rtu.py
@@ -121,7 +121,6 @@ class RtuMaster(Master):
         self._serial.flushOutput()
 
         self._serial.write(request)
-        time.sleep(self.get_timeout())
 
     def _recv(self, expected_length=-1):
         """Receive the response from the slave"""

--- a/modbus_tk/modbus_rtu.py
+++ b/modbus_tk/modbus_rtu.py
@@ -121,6 +121,7 @@ class RtuMaster(Master):
         self._serial.flushOutput()
 
         self._serial.write(request)
+        time.sleep(self.get_timeout())
 
     def _recv(self, expected_length=-1):
         """Receive the response from the slave"""

--- a/modbus_tk/utils.py
+++ b/modbus_tk/utils.py
@@ -10,6 +10,7 @@
 """
 from __future__ import print_function
 
+import sys
 import threading
 import logging
 import socket


### PR DESCRIPTION
See Issue #57 for details.