### PR TITLE
Allow caller to optionally override @threadsafe_function locking.

### DIFF
--- a/modbus_tk/utils.py
+++ b/modbus_tk/utils.py
@@ -25,14 +25,18 @@ def threadsafe_function(fcn):
     lock = threading.RLock()
 
     def new(*args, **kwargs):
-        """lock and call the decorated function"""
-        lock.acquire()
+        """Lock and call the decorated function
+
+           Unless kwargs['threadsafe'] == False
+        """
+        threadsafe = kwargs.pop('threadsafe', True)
+        if threadsafe: lock.acquire()
         try:
             ret = fcn(*args, **kwargs)
         except Exception as excpt:
             raise excpt
         finally:
-            lock.release()
+            if threadsafe: lock.release()
         return ret
     return new
 


### PR DESCRIPTION
This change gives the caller the ability to override the @threadsafe_function decorator by calling the decorated function, like execute(), with the kwarg 'threadsafe=False'.  This is useful when the client code is managing multiple modbus.Master instances, each in their own thread, and wants to avoid the global locking that takes place.

Here is psuedocode of what I am executing without error:

```

def modbus_worker(modbus_master):
   result = modbus_master.execute(..., threadsafe=False)
   print(result)

modbus_threads = []
for ip, port in devices:
   master = modbus_tcp.Master(host=ip, port=port)
   t = threading.Thread(target=modbus_worker, args=(master,))
   modbus_threads.append(t)
   t.start()
```

The default behavior is unchanged. Callers must include the new 'threadsafe' kwarg to avoid locking.
