### PR TITLE
Python 3 Integer Division

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -218,7 +218,7 @@ class Master(object):
                 byte_count =  struct.calcsize(data_format)
             else:
                 byte_count = 2 * len(output_value)
-            pdu = struct.pack(">BHHB", function_code, starting_address, byte_count / 2, byte_count)
+            pdu = struct.pack(">BHHB", function_code, starting_address, byte_count // 2, byte_count)
             if output_value and data_format:
                 pdu += struct.pack(data_format, *output_value)
             else:


### PR DESCRIPTION
Looks like a recent change broke Python3 support by trying to send floats to struck.pack(), which can only accept integers.  I believe the fix is just to add a single '/' to tell Python3 to do integer division.  I do not believe this has any impact on Python2, but I have not checked to be certain.