### PR TITLE
Fixed %s in get_values exception message

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -747,7 +747,7 @@ class Slave(object):
 
             if (offset < 0) or ((offset + size) > block.size):
                 raise OutOfModbusBlockError(
-                    "address %s size {0} is out of block {1}".format(address, size, block_name)
+                    "address {0} size {1} is out of block {2}".format(address, size, block_name)
                 )
 
             # returns the values


### PR DESCRIPTION
Used to print messages like 'modbus_tk.exceptions.OutOfModbusBlockError: address %s size 401 is out of block 16' because of partial conversion to .format function.