### PR TITLE
Fixes WRITE_SINGLE_COIL when Slave.unsigned == False

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -181,7 +181,9 @@ class Master(object):
             if function_code == defines.WRITE_SINGLE_COIL:
                 if output_value != 0:
                     output_value = 0xff00
-            fmt = ">BH"+("H" if output_value >= 0 else "h")
+                fmt = ">BHH"
+            else:
+                fmt = ">BH"+("H" if output_value >= 0 else "h")
             pdu = struct.pack(fmt, function_code, starting_address, output_value)
             if not data_format:
                 data_format = ">HH"
@@ -577,10 +579,9 @@ class Slave(object):
 
     def _write_single_coil(self, request_pdu):
         """execute modbus function 5"""
-        fmt = "H" if self.unsigned else "h"
 
         call_hooks("modbus.Slave.handle_write_single_coil_request", (self, request_pdu))
-        (data_address, value) = struct.unpack(">H"+fmt, request_pdu[1:5])
+        (data_address, value) = struct.unpack(">HH", request_pdu[1:5])
         block, offset = self._get_block_and_offset(defines.COILS, data_address, 1)
         if value == 0:
             block[offset] = 0

--- a/tests/functest_modbus_tcp.py
+++ b/tests/functest_modbus_tcp.py
@@ -152,6 +152,9 @@ class TcpTestQueries(TestQueries, unittest.TestCase):
     def _get_master(self):
         return modbus_tcp.TcpMaster()        
 
+class TcpTestQueriesSigned(TcpTestQueries, unittest.TestCase):
+
+    _unsigned = False
 
 class TestTcpSpecific(TestQueriesSetupAndTeardown, unittest.TestCase):
     


### PR DESCRIPTION
I don't think WRITE_SINGLE_COIL ever worked for Slaves where
self.unsigned == False.  The reason is that the Master always sets
a non-zero output_value to 0xff00 and packs it as unsigned.  The Slave
was looking at self.unsigned and then unpacking as a signed value if
self.unsigned == False.  This ensures a ModbusError on
modbus.py:590.

Also added some new "signed" unit tests.