### PR TITLE
Do not send response on invalid requests

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -829,6 +829,10 @@ class Databank(object):
                 # make the full response
                 response = query.build_response(response_pdu)
                 return response
+        except ModbusInvalidRequestError as excpt:
+            # Request is invalid, do not send any response
+            LOGGER.error("invalid request: " + str(excpt))
+            return ""
         except Exception as excpt:
             call_hooks("modbus.Databank.on_error", (self, excpt, request_pdu))
             LOGGER.error("handle request failed: " + str(excpt))

--- a/modbus_tk/modbus_rtu.py
+++ b/modbus_tk/modbus_rtu.py
@@ -243,8 +243,13 @@ class RtuServer(Server):
                     response = retval
 
                 if response:
-                    self._serial.write(response)
-                    time.sleep(self.get_timeout())
+                    if self._serial.in_waiting > 0:
+                        # Most likely master timed out on this request and started a new one
+                        # for which we already received atleast 1 byte
+                        LOGGER.warning("Not sending response because there is new request pending")
+                    else:
+                        self._serial.write(response)
+                        time.sleep(self.get_timeout())
 
                 call_hooks("modbus_rtu.RtuServer.after_write", (self, response))
 


### PR DESCRIPTION
Modbus slaves should not respond to Invalid CRC, "Too short message" and
Broadcast read requests.

Additionally, do not send response if data was received on line. This
most likely means that the master considered the previous request as
timed out and sent a new one.

Fixes: #85