### PR TITLE
Do not rely on receive timeout of serial port

### DIFF
--- a/modbus_tk/modbus_rtu.py
+++ b/modbus_tk/modbus_rtu.py
@@ -144,7 +144,7 @@ class RtuMaster(Master):
         startTime = time.time()
         while True:
             read_bytes = self._serial.read(expected_length if expected_length > 0 else 1)
-            if not read_bytes and ((time.time()-startTime) > self._serial.timeout or self.use_sw_timeout == False):
+            if not read_bytes and ((time.time()-startTime) > self._serial.timeout or self.use_sw_timeout != True):
                 break
             response += read_bytes
             if expected_length >= 0 and len(response) >= expected_length:

--- a/modbus_tk/modbus_rtu.py
+++ b/modbus_tk/modbus_rtu.py
@@ -139,9 +139,10 @@ class RtuMaster(Master):
     def _recv(self, expected_length=-1):
         """Receive the response from the slave"""
         response = utils.to_data("")
+        startTime = time.time()
         while True:
             read_bytes = self._serial.read(expected_length if expected_length > 0 else 1)
-            if not read_bytes:
+            if not read_bytes and (time.time()-startTime) > self._serial.timeout:
                 break
             response += read_bytes
             if expected_length >= 0 and len(response) >= expected_length:


### PR DESCRIPTION
With Windows 10 and Arduino MEGA and DUE as ModbusRTU slaves I have experienced that the serial receive timeout is not reliable. In many cases it immediately returns instead of waiting the set timeout time. This leads to errors even tough the slave answered immediately.
Additionally handling the receive timeout in the python script fixed this issue with unreliable driver implementations for me.