### PR TITLE
fixed deprecated isAlive

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -919,7 +919,7 @@ class Server(object):
 
     def stop(self):
         """stop the server. It doesn't handle request anymore"""
-        if self._thread.isAlive():
+        if self._thread.is_alive():
             self._go.clear()
             self._thread.join()
 

--- a/modbus_tk/utils.py
+++ b/modbus_tk/utils.py
@@ -211,7 +211,7 @@ class WorkerThread(object):
 
     def stop(self):
         """stop the thread"""
-        if self._thread.isAlive():
+        if self._thread.is_alive():
             self._go.clear()
             self._thread.join()
 


### PR DESCRIPTION
isAlive is deprecated. is_alive was added in Python 2.6. I don't know which is the oldest version which should be supported.