### PR TITLE
Make sure struct.unpack will work even when there are ascii in bytearray

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -16,6 +16,7 @@ from __future__ import with_statement
 
 import struct
 import threading
+import re
 
 from modbus_tk import LOGGER
 from modbus_tk import defines
@@ -328,7 +329,10 @@ class Master(object):
 
                 # returns the data as a tuple according to the data_format
                 # (calculated based on the function or user-defined)
-                result = struct.unpack(data_format, data)
+                if (re.match("[>]?[sp]?",data_format)):
+                    result = data.decode()
+                else:
+                    result = struct.unpack(data_format, data)
                 if nb_of_digits > 0:
                     digits = []
                     for byte_val in result:


### PR DESCRIPTION
Read string:
`logger.info(master.execute(1, cst.READ_HOLDING_REGISTERS, 49, 3,data_format='>s'))`

Example of generated error:
```
2021-04-25 11:10:12,072 DEBUG   modbus.execute  MainThread      -> 1-3-0-49-0-3-84-4
2021-04-25 11:10:12,101 DEBUG   modbus.execute  MainThread      <- 1-3-6-80-77-50-50-50-48-187-40
bytearray(b'\x03\x06PM2220')
Traceback (most recent call last):
  File "rtu_master_example_anel.py", line 59, in <module>
    main()
  File "rtu_master_example_anel.py", line 44, in main
    logger.info(master.execute(1, cst.READ_HOLDING_REGISTERS, 49, 3,data_format='>s'))
  File "C:\Users\B.I.O.S. S\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\modbus_tk\utils.py", line 39, in new
    raise excpt
  File "C:\Users\B.I.O.S. S\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\modbus_tk\utils.py", line 37, in new
    ret = fcn(*args, **kwargs)
  File "C:\Users\B.I.O.S. S\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.8_qbz5n2kfra8p0\LocalCache\local-packages\Python38\site-packages\modbus_tk\modbus.py", line 338, in execute
    result = struct.unpack(data_format, data)
struct.error: unpack requires a buffer of 1 bytes
```

Result of the patch:
```
2021-04-25 11:11:26,398 DEBUG   modbus.execute  MainThread      -> 1-3-0-49-0-3-84-4
2021-04-25 11:11:26,449 DEBUG   modbus.execute  MainThread      <- 1-3-6-80-77-50-50-50-48-187-40
bytearray(b'\x03\x06PM2220')
2021-04-25 11:11:26,450 INFO    rtu_master_example_anel.main    MainThread      PM2220

```