### PR TITLE
fix all tcp socket can't be delete

### DIFF
--- a/modbus_tk/modbus_tcp.py
+++ b/modbus_tk/modbus_tcp.py
@@ -275,9 +275,9 @@ class TcpServer(Server):
         for sock in self._sockets:
             try:
                 sock.close()
-                self._sockets.remove(sock)
             except Exception as msg:
                 LOGGER.warning("Error while closing socket, Exception occurred: %s", msg)
+        self._sockets = []
         self._sock.close()
         self._sock = None
 


### PR DESCRIPTION
when delete a object in 'for' iteration list, the list index will change and can't clear list. so some socket not closed