### PR TITLE
feat(logging): support logging of telegrams in hex format

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -84,6 +84,7 @@ class Master(object):
         """Constructor: can define a timeout"""
         self._timeout = timeout_in_sec
         self._verbose = False
+        self._print_in_hex = False
         self._is_opened = False
 
     def __del__(self):
@@ -93,6 +94,10 @@ class Master(object):
     def set_verbose(self, verbose):
         """print some more log prints for debug purpose"""
         self._verbose = verbose
+    
+    def print_telegrams_in_hex(self, print_in_hex):
+        """print telegrams in hex format"""
+        self._print_in_hex = print_in_hex
 
     def open(self):
         """open the communication with the slave"""
@@ -352,7 +357,7 @@ class Master(object):
         if retval is not None:
             request = retval
         if self._verbose:
-            LOGGER.debug(get_log_buffer("-> ", request))
+            LOGGER.debug(get_log_buffer("-> ", request, self._print_in_hex))
         self._send(request)
 
         call_hooks("modbus.Master.after_send", (self, ))
@@ -364,7 +369,7 @@ class Master(object):
             if retval is not None:
                 response = retval
             if self._verbose:
-                LOGGER.debug(get_log_buffer("<- ", response))
+                LOGGER.debug(get_log_buffer("<- ", response, self._print_in_hex))
 
             # extract the pdu part of the response
             response_pdu = query.parse_response(response)
@@ -1077,7 +1082,7 @@ class Server(object):
         """handle a received sentence"""
 
         if self._verbose:
-            LOGGER.debug(get_log_buffer("-->", request))
+            LOGGER.debug(get_log_buffer("-->", request, self._print_in_hex))
 
         # gets a query for analyzing the request
         query = self._make_query()
@@ -1092,5 +1097,5 @@ class Server(object):
             response = retval
 
         if response and self._verbose:
-            LOGGER.debug(get_log_buffer("<--", response))
+            LOGGER.debug(get_log_buffer("<--", response, self._print_in_hex))
         return response

--- a/modbus_tk/utils.py
+++ b/modbus_tk/utils.py
@@ -61,11 +61,14 @@ def flush_socket(socks, lim=0):
                 raise Exception("flush_socket: maximum number of iterations reached")
 
 
-def get_log_buffer(prefix, buff):
+def get_log_buffer(prefix, buff, print_in_hex = False):
     """Format binary data into a string for debug purpose"""
     log = prefix
     for i in buff:
-        log += str(ord(i) if PY2 else i) + "-"
+        if print_in_hex == True:
+            log += format(i, '02x') + "-"
+        else: 
+            log += str(ord(i) if PY2 else i) + "-"
     return log[:-1]
 
 


### PR DESCRIPTION
modbus telegrams are often better readable in hex format.

An application can enable hex logging of telegrams by calling the `print_telegrams_in_hex`  function
```python
modbusClient = OpenClient(config)
modbusClient.print_telegrams_in_hex(True)
```
example log in hex:
```shell
DEBUG:modbus_tk:-> 00-01-00-00-00-06-01-04-fa-01-00-1b
DEBUG:modbus_tk:<- 00-01-00-00-00-39-01-04-36-00-2a-37-4b-4d-33-32-32-30-2d-31-42-41-30-31-2d-31-4a-41-30-20-20-4c-51-4e-2f-32-32-30-35-33-31-38-38-30-30-30-38-00-01-44-03-03-00-00-00-f6-00-00-00-01-01-00-1e
```
