### PR TITLE
Add delays to avoid corrupting packages.

### DIFF
--- a/modbus_tk/modbus_rtu.py
+++ b/modbus_tk/modbus_rtu.py
@@ -274,6 +274,8 @@ class RtuServer(Server):
 
             # Read rest of the request
             while True:
+                # Add delays to avoid corrupting packages. (For use with FT232-RS485 device.)
+                time.sleep(0.001)
                 try:
                     read_bytes = self._serial.read(128)
                     if not read_bytes:


### PR DESCRIPTION
Add delays to solve corruption pack issue. (CH341 working well, but ft232 with vcp driver always corrupting.)
```
-->1-3-0-0-0-10-197-205
<--1-3-20-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-163-103
-->1-3-0-0-0-10-197-205
<--1-3-20-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-163-103
-->1-3-0-0-0-10-197-205
<--1-3-20-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-0-163-103
-->1
invalid request: Request length is invalid 1
-->3-0-0-0-10-197-205
invalid request: Invalid CRC in request
```