### PR TITLE
fix: allow for slave id 0

### DIFF
--- a/modbus_tk/modbus.py
+++ b/modbus_tk/modbus.py
@@ -357,7 +357,7 @@ class Master(object):
 
         call_hooks("modbus.Master.after_send", (self, ))
 
-        if slave != 0:
+        if slave is not None:
             # receive the data from the slave
             response = self._recv(expected_length)
             retval = call_hooks("modbus.Master.after_recv", (self, response))


### PR DESCRIPTION
I have some Modbus devices that use id 0. 
This change is seems to be sufficient, unless I'm missing some other reason to disallow slave=0.

This would also address issue #145 